### PR TITLE
Implement Randomly Test

### DIFF
--- a/data.py
+++ b/data.py
@@ -1,14 +1,18 @@
 class Word:
-    def __init__(self, word: str, meaning: str, wrong_nums: int):
+    def __init__(self, id: int, word: str, meaning: str, wrong_nums: int):
         """
         :param word: 단어
         :param meaning: 단어의 의미
         :param wrong_nums: 누적 틀린 횟수
         """
+        self.id = id
         self.word = word
         self.meaning = meaning
         self.wrong_nums = wrong_nums
         self.is_checked = False
+
+    def __str__(self):
+        return f"[#{self.id}] {self.word} / {self.wrong_nums}"
 
     def check_answer(self):
         print(f"meaning: {self.meaning}")

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+import random
+
 from utils import read_words_from_db, update_db, count_remaining_words
 
 EXCEL_FILE_PATH = "absolutely_essential_words_504.xls"
@@ -7,6 +9,7 @@ def run_test(day_index: int, file_path: str):
     words = read_words_from_db(file_path, day_index)
     remaining_words_num = count_remaining_words(words)
     while remaining_words_num != 0:
+        random.shuffle(words)
         for word in words:
             if not word.is_checked:
                 word.check_answer()

--- a/utils.py
+++ b/utils.py
@@ -17,31 +17,36 @@ def read_words_from_db(excel_file_path: str, day_index: int) -> List[Word]:
         if row_num == 0:
             continue
         word = Word(
-            word=sheet.cell_value(row_num, 0),
-            meaning=sheet.cell_value(row_num, 1),
-            wrong_nums=sheet.cell_value(row_num, 2),
+            id=int(sheet.cell_value(row_num, 0)),
+            word=sheet.cell_value(row_num, 1),
+            meaning=sheet.cell_value(row_num, 2),
+            wrong_nums=sheet.cell_value(row_num, 3),
         )
         words.append(word)
     return words
 
 
 def update_db(excel_file_path: str, day_index: int, words: List[Word]):
+    # ref: https://www.geeksforgeeks.org/ways-sort-list-dictionaries-values-python-using-lambda-function/
+    sorted_words = sorted(words, key=lambda w: w.id)
     # ref: https://www.blog.pythonlibrary.org/2014/03/24/creating-microsoft-excel-spreadsheets-with-python-and-xlwt/
     existing_workbook = xlrd.open_workbook(excel_file_path)
     new_wb = copy(existing_workbook)
     try:
         # 이미 존재하는 sheet를 가져와서 덮어쓴다.
         new_sheet = new_wb.get_sheet(day_index)
-        new_sheet.write(0, 0, "word")
-        new_sheet.write(0, 1, "meaning")
-        new_sheet.write(0, 2, "wrong_nums")
+        new_sheet.write(0, 0, "id")
+        new_sheet.write(0, 1, "word")
+        new_sheet.write(0, 2, "meaning")
+        new_sheet.write(0, 3, "wrong_nums")
     except IndexError:
         raise Exception("The sheet does not exist.")
 
-    for idx, word in enumerate(words):
-        new_sheet.write(idx + 1, 0, word.word)
-        new_sheet.write(idx + 1, 1, word.meaning)
-        new_sheet.write(idx + 1, 2, word.wrong_nums)
+    for idx, word in enumerate(sorted_words):
+        new_sheet.write(idx + 1, 0, word.id)
+        new_sheet.write(idx + 1, 1, word.word)
+        new_sheet.write(idx + 1, 2, word.meaning)
+        new_sheet.write(idx + 1, 3, word.wrong_nums)
     new_wb.save(excel_file_path)
 
 

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,6 @@
 from typing import List
 
 import xlrd
-import xlwt
 from xlutils.copy import copy
 
 from data import Word


### PR DESCRIPTION
- Resolve #5 

### 요약
- 테스트 1 iteration마다 테스트할 단어를 셔플링하는 로직을 추가했다.
- 셔플링으로 인해, 단어 테스트가 끝난 뒤 DB에 단어를 덮어쓰는 과정에서 순서가 바뀌는 문제가 발생했다. DB의 순서를 보장하기 위해, id 컬럼을 추가하고 DB에 데이터를 넣기 전에, word list를 id를 기준으로 정렬하도록 했다.

### (중요) TODO
- DB Schema가 변경되었으므로(word, meaning, wrong_nums) -> (id, word, meaning, wrong_nums), 이에 맞게 본인의 Excel DB를 변경해야 한다.